### PR TITLE
Supporting more shader types

### DIFF
--- a/src/glsl/mason/util.glsl
+++ b/src/glsl/mason/util.glsl
@@ -86,14 +86,29 @@ float noise3D( in vec3 x )
                    mix( hash(n+170.0), hash(n+171.0),f.x),f.y),f.z);
 }
 
-highp float random( vec2 co )
+float random( vec2 s )
 {
     highp float a = 12.9898;
     highp float b = 78.233;
     highp float c = 43758.5453;
-    highp float dt= dot( co.xy, vec2( a, b ) );
+    highp float dt= dot( s.xy, vec2( a, b ) );
     highp float sn= mod( dt, 3.14 );
     return fract(sin(sn) * c);
+}
+
+float random( float s )
+{
+	return random( vec2( s ) );
+}
+
+float random( vec2 s, float min, float max )
+{
+	return min + random( s ) * ( max - min );
+}
+
+float random( float s, float min, float max )
+{
+	return min + random( s ) * ( max - min );
 }
 
 float fbm( vec2 p )

--- a/src/glsl/mason/util.glsl
+++ b/src/glsl/mason/util.glsl
@@ -111,6 +111,11 @@ float random( float s, float min, float max )
 	return min + random( s ) * ( max - min );
 }
 
+float random( float s, vec2 minMaxRange )
+{
+	return minMaxRange[0] + random( s ) * ( minMaxRange[1] - minMaxRange[0] );
+}
+
 float fbm( vec2 p )
 {
 	const mat2 m = mat2( 0.80,  0.60, -0.60,  0.80 );

--- a/src/mason/Assets.cpp
+++ b/src/mason/Assets.cpp
@@ -292,8 +292,8 @@ ci::gl::GlslProgRef AssetManager::reloadShader( ci::gl::GlslProg::Format &format
 		group->addAsset( getAssetRef( shaderPath ) );
 
 		stageIncludedFiles.clear();
-		string parsedShader = mShaderPreprocessor.parse( format.getFragment(), shaderPath, &stageIncludedFiles );
-		format.fragment( parsedShader );
+		string parsedShader = mShaderPreprocessor.parse( format.getCompute(), shaderPath, &stageIncludedFiles );
+		format.compute( parsedShader );
 		sources.push_back( { shaderPath, parsedShader } );
 		includedFiles.insert( includedFiles.end(), stageIncludedFiles.begin(), stageIncludedFiles.end() );
 	}

--- a/src/mason/Assets.h
+++ b/src/mason/Assets.h
@@ -148,18 +148,13 @@ public:
 	//! Returns a unique ID based on the supplied string.
 	static uint32_t uuid( const std::string& str );
 
-	//! Returns the requested shader. Loads the files synchronously if the shader is not cached. Returns empty shader if the shader could not be compiled.
-	// TODO: rename all these to getGlsl()
-	ci::gl::GlslProgRef getShader( const ci::fs::path& vertex, const ci::gl::GlslProg::Format &format = ci::gl::GlslProg::Format() );
-	//! Returns the requested shader. Loads the files synchronously if the shader is not cached. Returns empty shader if the shader could not be compiled.
-	ci::gl::GlslProgRef getShader( const ci::fs::path& vertex, const ci::fs::path& fragment, const ci::gl::GlslProg::Format &format = ci::gl::GlslProg::Format() );
-	//!
+	//! Returns the requested shader within the provided \a updateCallback upon initial load and any time it is updated on file.
 	ci::signals::Connection getShader( const ci::fs::path& vertex, const ci::gl::GlslProg::Format &format, const std::function<void( ci::gl::GlslProgRef )> &updateCallback );
-	//!
+	//! Returns the requested shader within the provided \a updateCallback upon initial load and any time it is updated on file.
 	ci::signals::Connection getShader( const ci::fs::path& vertex, const ci::fs::path& fragment, const ci::gl::GlslProg::Format &format, const std::function<void( ci::gl::GlslProgRef )> &updateCallback );
-	//!
+	//! Returns the requested shader within the provided \a updateCallback upon initial load and any time it is updated on file.
 	ci::signals::Connection getShader( const ci::fs::path& vertex, const std::function<void( ci::gl::GlslProgRef )> &updateCallback )	{ return getShader( vertex, ci::gl::GlslProg::Format(), updateCallback ); }
-	//!
+	//! Returns the requested shader within the provided \a updateCallback upon initial load and any time it is updated on file.
 	ci::signals::Connection getShader( const ci::fs::path& vertex, const ci::fs::path& fragment, const std::function<void( ci::gl::GlslProgRef )> &updateCallback ) { return getShader( vertex, fragment, ci::gl::GlslProg::Format(), updateCallback ); }
 
 	//! Returns the requested texture. Loads the file synchronously if the texture is not cached. Returns empty texture if the file failed to load.

--- a/src/mason/Assets.h
+++ b/src/mason/Assets.h
@@ -145,9 +145,6 @@ public:
 	static AssetManager* instance();
 	~AssetManager();
 
-	//! Returns a unique ID based on the supplied string.
-	static uint32_t uuid( const std::string& str );
-
 	//! Returns the requested shader within the provided \a updateCallback upon initial load and any time it is updated on file.
 	ci::signals::Connection getShader( const ci::fs::path& vertex, const ci::gl::GlslProg::Format &format, const std::function<void( ci::gl::GlslProgRef )> &updateCallback );
 	//! Returns the requested shader within the provided \a updateCallback upon initial load and any time it is updated on file.


### PR DESCRIPTION
Shader type is now based on suffix, adhering to the suffixes chosen by the [Khronos Reference Compiler](https://www.khronos.org/opengles/sdk/tools/Reference-Compiler/).  This makes it possible to load compute shaders with `AssetManager`.

Also added some random() overloads to util.glsl.