### PR TITLE
Fix update

### DIFF
--- a/src/mason/Assets.cpp
+++ b/src/mason/Assets.cpp
@@ -319,12 +319,10 @@ signals::Connection AssetManager::getTexture( const ci::fs::path &texturePath, c
 
 				notifyResourceReloaded();
 				mAssetErrors.erase( hash );
-
-				if( updateCallback )
-					updateCallback( texture );
-
-
 			}
+
+			if( texture && updateCallback )
+				updateCallback( texture );
 		}
 		catch( const exception &exc ) {
 			if( mAssetErrors.count( hash ) == 0 ) {


### PR DESCRIPTION
When you use:
```
mConnections += ma::assets()->getTexture( "texture.png", [this]( gl::Texture2dRef texture ) { mTexture = texture; } );
```
, the callback is only called the first time the texture is loaded this way. Any subsequent calls (from other scripts) won't cause `mTexture` to be assigned the texture. This PR attempts to remedy that.